### PR TITLE
Implement Connection callbacks

### DIFF
--- a/lib/s2-ruby.rb
+++ b/lib/s2-ruby.rb
@@ -10,6 +10,7 @@ require_relative "s2/messages/handshake_response"
 require_relative "s2/messages/reception_status"
 require_relative "s2/message_factory"
 require_relative "s2/message_handler"
+require_relative "s2/message_handler_callbacks"
 require_relative "s2/connection"
 
 module S2

--- a/lib/s2/message_handler_callbacks.rb
+++ b/lib/s2/message_handler_callbacks.rb
@@ -1,0 +1,39 @@
+module S2
+  module MessageHandlerCallbacks
+    extend ActiveSupport::Concern
+
+    included do
+      class_attribute :on_open_proc, default: nil
+      class_attribute :before_receive_proc, default: nil
+      class_attribute :after_send_proc, default: nil
+    end
+
+    class_methods do
+      def on_open(&block)
+        self.on_open_proc = block
+      end
+
+      def before_receive(&block)
+        self.before_receive_proc = block
+      end
+
+      def after_send(&block)
+        self.after_send_proc = block
+      end
+    end
+
+    protected
+
+    def trigger_on_open(rm_id)
+      instance_exec(rm_id, &self.class.on_open_proc) if self.class.on_open_proc
+    end
+
+    def trigger_before_receive(rm_id, message)
+      instance_exec(rm_id, message, &self.class.before_receive_proc) if self.class.before_receive_proc
+    end
+
+    def trigger_after_send(rm_id, message)
+      instance_exec(rm_id, message, &self.class.after_send_proc) if self.class.after_send_proc
+    end
+  end
+end


### PR DESCRIPTION
Allows for defining callbacks in a connection implementation:

```ruby
on_open { |rm_id| puts rm_id }
before_receive { |rm_id, message_json| puts message_json }
after_send { |rm_id, message_json| puts message_json }
```