### PR TITLE
Rename rm_id to context

### DIFF
--- a/lib/s2/connection.rb
+++ b/lib/s2/connection.rb
@@ -18,18 +18,18 @@ module S2
       @ws = ws
       @logger = logger
       @sent_messages = {}
-      @rm_id = nil
+      @context = nil
 
       update_state :connected
     end
 
-    def open(rm_id)
-      @rm_id = rm_id
-      trigger_on_open(rm_id)
+    def open(context)
+      @context = context
+      trigger_on_open(context)
     end
 
     def receive_message(message_json)
-      trigger_before_receive(@rm_id, message_json)
+      trigger_before_receive(@context, message_json)
       @logger.info("Received message: #{message_json}")
 
       message = deserialize_message(message_json)
@@ -45,7 +45,7 @@ module S2
       store_sent_message(message) unless message.is_a?(S2::Messages::ReceptionStatus)
       json = message.to_json
       send_raw_message(json)
-      trigger_after_send(@rm_id, json)
+      trigger_after_send(@context, json)
 
       @logger.info("Sent message: #{json}")
     end


### PR DESCRIPTION
It is not CEM specific, so the naming should be role agnostic