### PR TITLE
Release the websocket promptly when a connection is disconnected

### DIFF
--- a/lib/s2/connection.rb
+++ b/lib/s2/connection.rb
@@ -9,7 +9,7 @@ module S2
 
     attr_reader :connected_at, :status
 
-    def initialize(resource_id:, task:, ws_url:, headers: {})
+    def initialize(resource_id:, ws_url:, task: nil, headers: {})
       @connected_at = nil
       @queue = nil
       @resource_id = resource_id
@@ -27,6 +27,8 @@ module S2
     end
 
     def connect
+      @task ||= Async::Task.current
+
       until @stopping
         begin
           connect_and_run
@@ -61,6 +63,7 @@ module S2
         # ignore
       end
 
+      @task&.stop
       @status = :disconnected
     end
 

--- a/spec/s2/connection_spec.rb
+++ b/spec/s2/connection_spec.rb
@@ -15,11 +15,7 @@ describe S2::Connection, :async do
       resource_id = SecureRandom.uuid
       ws_url = "ws://example.com/#{resource_id}"
 
-      connection = described_class.new(
-        resource_id:,
-        task: Async::Task.current,
-        ws_url:,
-      )
+      connection = described_class.new(resource_id:, ws_url:)
 
       allow(connection).to receive(:sleep) { |duration| sleep_durations << duration }
 
@@ -48,12 +44,7 @@ describe S2::Connection, :async do
       ws_url = "ws://example.com/#{resource_id}"
       headers = { "authorization" => "Basic dXNlcjpwYXNz" }
 
-      connection = described_class.new(
-        resource_id:,
-        task: Async::Task.current,
-        ws_url:,
-        headers:,
-      )
+      connection = described_class.new(resource_id:, ws_url:, headers:)
 
       task = Async do
         connection.connect
@@ -81,11 +72,7 @@ describe S2::Connection, :async do
       resource_id = SecureRandom.uuid
       ws_url = "ws://example.com/#{resource_id}"
 
-      connection = described_class.new(
-        resource_id:,
-        task: Async::Task.current,
-        ws_url:,
-      )
+      connection = described_class.new(resource_id:, ws_url:)
 
       allow(connection).to receive(:sleep)
 
@@ -100,6 +87,25 @@ describe S2::Connection, :async do
 
       expect(connection_attempts.size).to be >= 3
       expect(connection_attempts.uniq.size).to eq(1)
+    end
+
+    it "stops its task when disconnected, even while sleeping between reconnect attempts" do
+      allow(Async::WebSocket::Client).to receive(:connect).and_raise(Errno::ECONNREFUSED)
+
+      resource_id = SecureRandom.uuid
+      ws_url = "ws://example.com/#{resource_id}"
+
+      connection = described_class.new(resource_id:, ws_url:)
+
+      task = Async { connection.connect }
+      Async::Task.current.sleep 0.1
+
+      expect(task).not_to be_finished
+
+      connection.disconnect
+
+      Async::Task.current.sleep 0.1
+      expect(task).to be_finished
     end
 
     it "instruments connection_errored with the resource_id and exception" do
@@ -122,7 +128,6 @@ describe S2::Connection, :async do
 
       connection = described_class.new(
         resource_id:,
-        task: Async::Task.current,
         ws_url: "ws://example.com/#{resource_id}",
       )
       allow(connection).to receive(:sleep)


### PR DESCRIPTION
We+ CEM heeft StekkerS2 vorige week 20+ minuten geweerd met een 403 ("you already have an RM connection") terwijl wij in een reconnect-cyclus zaten. CEM-kant zag de oude TCP/WS-connectie nog als levend; pas toen onze app uiteindelijk een CLOSE 1000 verstuurde, lukte de eerstvolgende poging.

Oorzaak in deze gem: `S2::Connection#disconnect` zet `@stopping = true` en roept `@session&.stop` aan — maar tussen reconnect-iteraties is `@session = nil` (gezet in de `ensure` van `connect_and_run`), dus die roep is een no-op. De running async task (en daarmee de open WebSocket binnen `Async::WebSocket::Client.connect(...) do |ws| ... end`) blijft daardoor leven tot iets *anders* hem ontwart. CLOSE 1000 wordt pas verstuurd wanneer de block-form alsnog uitloopt, in productie minutenlang na de eigenlijke `disconnect`-call.

Fix:

- `task:` is nu optioneel in `S2::Connection.new`. In `connect` lazy resolved naar `Async::Task.current` (= de task die `connect` daadwerkelijk draait).
- `disconnect` roept `@task&.stop` aan. Dat raised `Async::Stop` in de task, ontwart `sleep @backoff` of een blocking `@ws.read`, de ensures vuren, de block-form sluit de WebSocket en stuurt CLOSE 1000 — direct in plaats van na een onbepaalde tijd.

Bestaande specs gaven `task: Async::Task.current` mee, wat feitelijk de OUTER spec-task was (niet de task die `connect` draait). Met de fix zou dat de spec laten crashen; daarom is het argument weggehaald. Nieuwe spec bewijst dat `disconnect` alleen al de task termineert terwijl die in `sleep @backoff` zit — red-green-bevestigd door de fix even terug te draaien.

Na merge: gem-pin in `StekkerS2/Gemfile.lock` bumpen, daar volgt aansluitend een PR voor.